### PR TITLE
fix: Improve search result highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-tailwind-theme",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A JupyterLab theme extension inspired by Tailwind CSS.",
   "author": "simicd <10134699+simicd@users.noreply.github.com>",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,10 @@ const plugin: JupyterFrontEndPlugin<void> = {
         document.documentElement.style.setProperty('--jp-mirror-editor-hr-color', '#999');
         document.documentElement.style.setProperty('--jp-notebook-multiselected-color', 'var(--tailwind-blue-100)');
 
+        // Search result highlighting
+        document.documentElement.style.setProperty('--jp-search-selected-match-background-color', 'var(--tailwind-green-400)');
+        document.documentElement.style.setProperty('--jp-search-unselected-match-background-color', 'var(--tailwind-green-200)');
+
         return manager.loadCSS(style)
       },
       unload: () => Promise.resolve(undefined)
@@ -124,6 +128,10 @@ const plugin: JupyterFrontEndPlugin<void> = {
         document.documentElement.style.setProperty('--jp-mirror-editor-error-color', '#f00');
         document.documentElement.style.setProperty('--jp-mirror-editor-hr-color', '#999');
         document.documentElement.style.setProperty('--jp-notebook-multiselected-color', 'var(--tailwind-blue-900)');
+
+        // Search result highlighting
+        document.documentElement.style.setProperty('--jp-search-selected-match-background-color', 'var(--tailwind-green-600)');
+        document.documentElement.style.setProperty('--jp-search-unselected-match-background-color', 'var(--tailwind-green-800)');
 
         return manager.loadCSS(style)
       },

--- a/style/index.css
+++ b/style/index.css
@@ -114,6 +114,14 @@ button.jp-Button.bp3-button.bp3-minimal:hover {
   padding: calc(var(--jp-code-padding) / 2);
 }
 
+/* Search highlight - make 1px higher to cover grey background */
+.cm-searching {
+  padding: 2px 2px;
+  margin: -2px -2px;
+  position: relative;     /* Set position since with default (position: static) z-index has no effect */
+  z-index: -10;           /* Position highlighting behind text */
+}
+
 /* Max-widht for main content/cell blocks */
 .jp-Notebook .jp-Cell {
   max-width: 1000px;

--- a/style/variables.css
+++ b/style/variables.css
@@ -89,6 +89,16 @@ all of MD as it is not optimized for dense, information rich UIs.
   --tailwind-orange-800: #9C4221;
   --tailwind-orange-900: #7B341E;
 
+  --tailwind-yellow-100: #FFFFF0;
+  --tailwind-yellow-200: #FEFCBF;
+  --tailwind-yellow-300: #FAF089;
+  --tailwind-yellow-400: #F6E05E;
+  --tailwind-yellow-500: #ECC94B;
+  --tailwind-yellow-600: #D69E2E;
+  --tailwind-yellow-700: #B7791F;
+  --tailwind-yellow-800: #975A16;
+  --tailwind-yellow-900: #744210;
+
   --tailwind-red-100: #FFF5F5;
   --tailwind-red-200: #FED7D7;
   --tailwind-red-300: #FEB2B2;
@@ -435,6 +445,10 @@ all of MD as it is not optimized for dense, information rich UIs.
   /* General editor styles */
 
   --jp-editor-selected-background: #d9d9d9;
+  /* --jp-search-selected-match-color: var(--); */
+  --jp-search-selected-match-background-color: var(--tailwind-green-400);
+  /* --jp-search-unselected-match-color: var(--); */
+  --jp-search-unselected-match-background-color: var(--tailwind-green-200);
   --jp-editor-selected-focused-background: #d7d4f0;
   --jp-editor-cursor-color: var(--jp-ui-font-color0);
 


### PR DESCRIPTION
Previously the search results in JupyterLab were displayed with a gray background which was barely visible. Newly, the color is brighter and differentiated between light & dark theme. See also #9.